### PR TITLE
Switch default C++ compiler to clang from gcc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -36,22 +36,22 @@ build --define=grpc_no_ares=true
 # googletest requires absl flags.
 build --define=absl=1
 
-# `--config=clang` will build with clang and libc++.
-build:clang --repo_env=CC=clang --repo_env=CXX=clang++ --linkopt=-fuse-ld=lld
-build:clang --cxxopt=-stdlib=libc++ --linkopt=-stdlib=libc++
+# Default build with clang and libc++.
+build --repo_env=CC=clang --repo_env=CXX=clang++ --linkopt=-fuse-ld=lld
+build --cxxopt=-stdlib=libc++ --linkopt=-stdlib=libc++
 
 # This results in -Werror for all FCP code, but nothing we pull in via
 # repository rules (those labels have a @ prefix).
-build:clang --per_file_copt=+^//@-Werror
+build --per_file_copt=+^//@-Werror
 # We pull in some headers from TensorFlow which give the following warning, we
 # don't want to convert them to errors.
-build:clang --per_file_copt=+^//@-Wno-error=ignored-qualifiers
-build:clang --per_file_copt=+^//@-Wno-error=inconsistent-missing-override
-build:clang --per_file_copt=+^//@-Wno-error=mismatched-tags
-build:clang --per_file_copt=+^//@-Wno-error=defaulted-function-deleted
+build --per_file_copt=+^//@-Wno-error=ignored-qualifiers
+build --per_file_copt=+^//@-Wno-error=inconsistent-missing-override
+build --per_file_copt=+^//@-Wno-error=mismatched-tags
+build --per_file_copt=+^//@-Wno-error=defaulted-function-deleted
 # Some of the opstats.proto enums are deprecated, but until all references to
 # them have been removed we should be allowed to use them.
-build:clang --per_file_copt=+^//@-Wno-error=deprecated-declarations
+build --per_file_copt=+^//@-Wno-error=deprecated-declarations
 
 # TF now has `cc_shared_library` targets, so it needs the experimental flag.
 build --experimental_cc_shared_library

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -7,24 +7,14 @@
 There are some basic tools and packages you will need on your machine:
 
 *   Git
-*   A C++ compiler (e.g., Clang or GCC, but see note about GCC below)
+*   C++ Clang compiler
 *   Python 3.9 or greater, including the `venv` module
 
 For example, on Debian:
 
 ```
-sudo apt install -y git gcc python3 python3-dev python3-venv
+sudo apt install -y git clang lld libc++-dev libc++abi-dev python3 python3-dev python3-venv
 ```
-
-> ⚠️ The project maintainers internally test with Clang only, so support for
-> GCC-based builds is provided only on a best-effort basis and may at times be
-> broken.
->
-> If using GCC then we recommend using a recent version (e.g., at least as
-> recent as what Debian stable uses, preferably newer than that).
->
-> If using Clang then please see [Building with Clang](#building-with-clang) for
-> further Clang-specific instructions.
 
 ### Install Bazelisk
 
@@ -72,13 +62,4 @@ python3 -c "import tensorflow_federated"
 
 ```
 bazelisk test //fcp/demo:federated_program_test
-```
-
-### Building with Clang
-
-Use `--config=clang` to build with clang and libc++. On Debian, this requires
-installing several additional packages:
-
-```
-sudo apt install -y clang lld libc++-dev libc++abi-dev
 ```


### PR DESCRIPTION
This PR switches the default C++ compiler to clang from gcc. 